### PR TITLE
allowing for not using versioned symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.scom/vsoch/elfcall/tree/main) (0.0.x)
+ - add default argument to not use symbol versions (0.0.13)
  - add support to provide custom LD_LIBRARY_PATH (0.0.12)
    - loosen matching constaint to not include type
  - Bugfix in function name (0.0.11)

--- a/elfcall/version.py
+++ b/elfcall/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2022, Vanessa Sochat"
 __license__ = "GPL-3.0"
 
-__version__ = "0.0.12"
+__version__ = "0.0.13"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.io"
 NAME = "elfcall"


### PR DESCRIPTION
Since we are splicing, we do not want to fail matching a symbol because the version is different. Ideally we can do a lookup but this quick fix should work for now for this splice use case

This PR is for the BUILD SI project.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>